### PR TITLE
Fix bug in removelast function of the linked list deque implementation

### DIFF
--- a/prose/05_deques_lls.md
+++ b/prose/05_deques_lls.md
@@ -162,7 +162,7 @@ class LinkedList:
 
     def addlast(self, item):
         if self._head is None:
-            self.add(item)
+            self.addfirst(item)
         else:
             self._tail.link = ListNode(item)
             self._tail = self._tail.link

--- a/prose/05_deques_lls.md
+++ b/prose/05_deques_lls.md
@@ -119,8 +119,9 @@ class LinkedList:
             currentnode = self._head
             while currentnode.link.link is not None:
                 currentnode = currentnode.link
+            item = currentnode.link.data
             currentnode.link = None
-            return currentnode.data
+            return item
 ```
 
 ```python {cmd hide continue="linkedlist_A"}


### PR DESCRIPTION
Hi! I spotted:
- An error in the `removelast` function of the linked list deque implementation. The function should be returning the current node's link's data, instead of current node's data. I verified this corrected behavior with a few unit tests on my local dev environment. 
- A little error in the tailed link list deque implementation code, where `addlast` function makes a call to `add` when it should be calling `addfirst`
If you'd like to review this PR, I'd be happy to contribute to this great content that you've created. Thanks for your efforts and sharing!